### PR TITLE
tweak imports

### DIFF
--- a/Modules/GoobStation/Content.Goobstation.Client/Content.Goobstation.Client.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Client/Content.Goobstation.Client.csproj
@@ -1,25 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <TargetFramework>$(TargetFramework)</TargetFramework>
-      <IsPackable>false</IsPackable>
       <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
       <OutputType Condition="'$(FullRelease)' != 'True'">Exe</OutputType>
       <WarningsAsErrors>RA0032;nullable</WarningsAsErrors>
-      <Nullable>enable</Nullable>
-      <Configurations>Debug;Release;Tools;DebugOpt</Configurations>
-      <Platforms>AnyCPU</Platforms>
     </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Nett" />
-    <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
-    <PackageReference Include="SixLabors.ImageSharp" />
-    <PackageReference Include="Pidgin" />
-    <PackageReference Include="Robust.Shared.AuthLib" />
-  </ItemGroup>
+    <Import Project="..\..\..\MSBuild\Content.props"/>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\Content.Client\Content.Client.csproj" />
+      <ProjectReference Include="..\Content.Goobstation.Common\Content.Goobstation.Common.csproj" />
       <ProjectReference Include="..\Content.Goobstation.Shared\Content.Goobstation.Shared.csproj" />
     </ItemGroup>
 

--- a/Modules/GoobStation/Content.Goobstation.Client/Content.Goobstation.Client.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Client/Content.Goobstation.Client.csproj
@@ -4,7 +4,7 @@
       <IsPackable>false</IsPackable>
       <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
       <OutputType Condition="'$(FullRelease)' != 'True'">Exe</OutputType>
-      <WarningsAsErrors>nullable</WarningsAsErrors>
+      <WarningsAsErrors>RA0032;nullable</WarningsAsErrors>
       <Nullable>enable</Nullable>
       <Configurations>Debug;Release;Tools;DebugOpt</Configurations>
       <Platforms>AnyCPU</Platforms>
@@ -12,12 +12,20 @@
 
   <ItemGroup>
     <PackageReference Include="Nett" />
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
+    <PackageReference Include="SixLabors.ImageSharp" />
+    <PackageReference Include="Pidgin" />
+    <PackageReference Include="Robust.Shared.AuthLib" />
   </ItemGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\..\..\Content.Client\Content.Client.csproj" />
       <ProjectReference Include="..\Content.Goobstation.Shared\Content.Goobstation.Shared.csproj" />
     </ItemGroup>
+
+    <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
+    <Import Project="..\..\..\RobustToolbox\Imports\Client.props" />
+    <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
 
     <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
     <Import Project="..\..\..\RobustToolbox\MSBuild\XamlIL.targets" />

--- a/Modules/GoobStation/Content.Goobstation.Common/Content.Goobstation.Common.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Common/Content.Goobstation.Common.csproj
@@ -1,12 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
     </PropertyGroup>
 
-
-      <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
+  <Import Project="..\..\..\MSBuild\Content.props"/>
+  <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
 
   <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Server.props" />

--- a/Modules/GoobStation/Content.Goobstation.Common/Content.Goobstation.Common.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Common/Content.Goobstation.Common.csproj
@@ -4,10 +4,11 @@
     </PropertyGroup>
 
   <Import Project="..\..\..\MSBuild\Content.props"/>
-  <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
 
   <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Server.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Packaging.props" />
+
+  <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
 </Project>

--- a/Modules/GoobStation/Content.Goobstation.Common/Content.Goobstation.Common.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Common/Content.Goobstation.Common.csproj
@@ -5,8 +5,11 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\..\RobustToolbox\Robust.Shared\Robust.Shared.csproj"/>
-    </ItemGroup>
 
+      <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
+
+  <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
+  <Import Project="..\..\..\RobustToolbox\Imports\Server.props" />
+  <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
+  <Import Project="..\..\..\RobustToolbox\Imports\Packaging.props" />
 </Project>

--- a/Modules/GoobStation/Content.Goobstation.Server.Database/Content.Goobstation.Server.Database.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Server.Database/Content.Goobstation.Server.Database.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
+  <Import Project="..\..\..\MSBuild\Content.props"/>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">

--- a/Modules/GoobStation/Content.Goobstation.Server/Content.Goobstation.Server.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Server/Content.Goobstation.Server.csproj
@@ -1,16 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net10.0</TargetFramework>
+    <TargetFramework>$(TargetFramework)</TargetFramework>
     <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputType Condition="'$(FullRelease)' != 'True'">Exe</OutputType>
     <NoWarn>1998</NoWarn>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
+    <WarningsAsErrors>RA0032;nullable</WarningsAsErrors>
     <Nullable>enable</Nullable>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
+    <PackageReference Include="NetCord" />
+    <PackageReference Include="prometheus-net" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Content.Server\Content.Server.csproj" />
@@ -19,4 +26,10 @@
     <ProjectReference Include="..\Content.Goobstation.Shared\Content.Goobstation.Shared.csproj" />
   </ItemGroup>
 
+  <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
+
+  <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
+  <Import Project="..\..\..\RobustToolbox\Imports\Server.props" />
+  <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
+  <Import Project="..\..\..\RobustToolbox\Imports\Packaging.props" />
 </Project>

--- a/Modules/GoobStation/Content.Goobstation.Server/Content.Goobstation.Server.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Server/Content.Goobstation.Server.csproj
@@ -17,10 +17,10 @@
     <ProjectReference Include="..\Content.Goobstation.Shared\Content.Goobstation.Shared.csproj" />
   </ItemGroup>
 
-  <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
-
   <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Server.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Packaging.props" />
+
+  <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
 </Project>

--- a/Modules/GoobStation/Content.Goobstation.Server/Content.Goobstation.Server.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Server/Content.Goobstation.Server.csproj
@@ -1,23 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFramework)</TargetFramework>
-    <IsPackable>false</IsPackable>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <OutputType Condition="'$(FullRelease)' != 'True'">Exe</OutputType>
     <NoWarn>1998</NoWarn>
     <WarningsAsErrors>RA0032;nullable</WarningsAsErrors>
-    <Nullable>enable</Nullable>
     <ServerGarbageCollection>true</ServerGarbageCollection>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
-    <PackageReference Include="NetCord" />
-    <PackageReference Include="prometheus-net" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" />
-  </ItemGroup>
+  <Import Project="..\..\..\MSBuild/Content.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Content.Server\Content.Server.csproj" />

--- a/Modules/GoobStation/Content.Goobstation.Shared/Content.Goobstation.Shared.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Shared/Content.Goobstation.Shared.csproj
@@ -1,15 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
+      <TargetFramework>$(TargetFramework)</TargetFramework>
+      <IsPackable>false</IsPackable>
+      <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+      <WarningsAsErrors>RA0032;nullable</WarningsAsErrors>
       <Nullable>enable</Nullable>
     </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
+    <PackageReference Include="YamlDotNet" />
+  </ItemGroup>
+
+    <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
+  <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
+
     <ItemGroup>
-      <ProjectReference Include="..\..\..\RobustToolbox\Robust.Shared\Robust.Shared.csproj" />
       <ProjectReference Include="..\Content.Goobstation.Common\Content.Goobstation.Common.csproj" />
       <ProjectReference Include="..\..\..\Content.Shared\Content.Shared.csproj" />
     </ItemGroup>
 
+    <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
+      <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.CompNetworkGenerator.targets" />
 </Project>

--- a/Modules/GoobStation/Content.Goobstation.Shared/Content.Goobstation.Shared.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Shared/Content.Goobstation.Shared.csproj
@@ -1,19 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <TargetFramework>$(TargetFramework)</TargetFramework>
-      <IsPackable>false</IsPackable>
       <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
       <WarningsAsErrors>RA0032;nullable</WarningsAsErrors>
-      <Nullable>enable</Nullable>
     </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" PrivateAssets="All" />
-    <PackageReference Include="YamlDotNet" />
-  </ItemGroup>
+    <Import Project="..\..\..\MSBuild\Content.props"/>
 
     <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
-  <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
+    <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
 
     <ItemGroup>
       <ProjectReference Include="..\Content.Goobstation.Common\Content.Goobstation.Common.csproj" />
@@ -21,5 +15,5 @@
     </ItemGroup>
 
     <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
-      <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.CompNetworkGenerator.targets" />
+    <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.CompNetworkGenerator.targets" />
 </Project>

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We are not currently accepting translations of the game on our main repository. 
 
 1. Clone this repo.
 2. Run `RUN_THIS.py` to init submodules and download the engine.
-3. <b style="color:crimson;">Different from other SS14 projects! </b>Compile the solution with`dotnet run Goobstation.Bootstrap`
+3. <b style="color:crimson;">Different from other SS14 projects! </b>Compile the solution with `dotnet run --project Goobstation.Bootstrap`
 
 [More detailed instructions on building the project.](https://docs.goobstation.com/en/general-development/setup.html)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ We are not currently accepting translations of the game on our main repository. 
 
 1. Clone this repo.
 2. Run `RUN_THIS.py` to init submodules and download the engine.
-3. Compile the solution.
+3. <b style="color:crimson;">Different from other SS14 projects! </b>Compile the solution with`dotnet run Goobstation.Bootstrap`
 
 [More detailed instructions on building the project.](https://docs.goobstation.com/en/general-development/setup.html)
 


### PR DESCRIPTION
Updates csproj to not be bad

Adds a nice bold text in readme to point people to

Changes:

- `LangVersion`, `IsPackable`, and `Nullable` now pulled from `MSBuild/Content.props`
- Added imports for RT projects, mirrored 1:1 with wiz setup
- Added RT.props.targets, which necessitates removal of direct project refs
- Basically imitated `github.com/space-wizards/space-station-14/pull/41855`
- RA0032 is an error too (like in wiz, can't disagree THO it should just fail to compile instead of analysis)

Also an image of content in goobstation.server calling things like lightning from content.server
<img width="312" height="180" alt="{CB5599D5-0889-494B-B9A7-CCA3D36A76D3}" src="https://github.com/user-attachments/assets/37b824df-2187-43fa-8f24-1bc6acb1ac9f" />
