### PR TITLE
Bootstrap improvements

### DIFF
--- a/Goobstation.Bootstrap/BootstrapBuilder.cs
+++ b/Goobstation.Bootstrap/BootstrapBuilder.cs
@@ -69,6 +69,52 @@ public static class BootstrapBuilder
         return Task.CompletedTask;
     }
 
+    public static Task BuildClient()
+    {
+        var modules = ModuleDiscovery.DiscoverModules().Where(module => module.Type is not ModuleRole.Server).ToList();
+
+        Console.WriteLine("Building core projects...");
+        RunDotnetBuild("Content.Client/Content.Client.csproj");
+
+        foreach (var module in modules)
+        {
+            Console.WriteLine($"Building module {module.Name}...");
+            RunDotnetBuild(module.ProjectPath);
+        }
+
+        foreach (var module in modules)
+        {
+            Console.WriteLine($"Copying {module.Name} outputs...");
+            CopyModuleOutputs(module, "bin/Content.Client");
+        }
+
+        Console.WriteLine("Build complete.");
+        return Task.CompletedTask;
+    }
+
+    public static Task BuildServer()
+    {
+        var modules = ModuleDiscovery.DiscoverModules().Where(module => module.Type is not ModuleRole.Client).ToList();
+
+        Console.WriteLine("Building core projects...");
+        RunDotnetBuild("Content.Server/Content.Server.csproj");
+
+        foreach (var module in modules)
+        {
+            Console.WriteLine($"Building module {module.Name}...");
+            RunDotnetBuild(module.ProjectPath);
+        }
+
+        foreach (var module in modules)
+        {
+            Console.WriteLine($"Copying {module.Name} outputs...");
+            CopyModuleOutputs(module, "bin/Content.Server");
+        }
+
+        Console.WriteLine("Build complete.");
+        return Task.CompletedTask;
+    }
+
     private static void RunDotnetBuild(string projectPath)
     {
         var psi = new ProcessStartInfo

--- a/Goobstation.Bootstrap/BootstrapBuilder.cs
+++ b/Goobstation.Bootstrap/BootstrapBuilder.cs
@@ -20,7 +20,7 @@ public static class BootstrapBuilder
         return "dotnet";
     }
 
-    private static string FindRepoRoot()
+    public static string FindRepoRoot()
     {
         var dir = AppContext.BaseDirectory;
         while (dir != null)
@@ -34,9 +34,6 @@ public static class BootstrapBuilder
 
     public static Task BuildAll()
     {
-        var repoRoot = FindRepoRoot();
-        Environment.CurrentDirectory = repoRoot;
-
         var modules = ModuleDiscovery.DiscoverModules().ToList();
 
         Console.WriteLine("Building core projects...");

--- a/Goobstation.Bootstrap/CommandLineArgs.cs
+++ b/Goobstation.Bootstrap/CommandLineArgs.cs
@@ -19,13 +19,19 @@ public sealed class CommandLineArgs
     /// </summary>
     public bool SkipBuild { get; set; }
 
+    /// <summary>
+    /// Should we open a new shell for the run project.
+    /// </summary>
+    public bool ShellExecute { get; set; }
+
     // CommandLineArgs, 3rd of her name.
     public static bool TryParse(IReadOnlyList<string> args, [NotNullWhen(true)] out CommandLineArgs? parsed)
     {
         parsed = null;
-        bool client = true;
-        bool server = true;
+        var client = true;
+        var server = true;
         var skipBuild = false;
+        var shellExecute = true;
 
         using var enumerator = args.GetEnumerator();
         var i = -1;
@@ -52,6 +58,9 @@ public sealed class CommandLineArgs
                 case "--skip-build":
                     skipBuild = true;
                     break;
+                case "--no-shell-execute":
+                    shellExecute = false;
+                    break;
                 case "--help":
                     PrintHelp();
                     return false;
@@ -61,7 +70,7 @@ public sealed class CommandLineArgs
             }
         }
 
-        parsed = new CommandLineArgs(client, server, skipBuild);
+        parsed = new CommandLineArgs(client, server, skipBuild, shellExecute);
         return true;
     }
 
@@ -71,17 +80,20 @@ public sealed class CommandLineArgs
 Usage: Goobstation.Bootstrap [client/server/(both)] [options]
 
 Options:
-  --skip-build          Should we skip building the project and use what's already there.
+  --skip-build          Skips building the project and uses what's already there.
+  --no-shell-execute    Doesn't open a new shell and instead uses the bootstrap shell for logs.
 ");
     }
 
     private CommandLineArgs(
         bool client,
         bool server,
-        bool skipBuild)
+        bool skipBuild,
+        bool shellExecute)
     {
         Client = client;
         Server = server;
         SkipBuild = skipBuild;
+        ShellExecute = shellExecute;
     }
 }

--- a/Goobstation.Bootstrap/CommandLineArgs.cs
+++ b/Goobstation.Bootstrap/CommandLineArgs.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Goobstation.Bootstrap;
+
+public sealed class CommandLineArgs
+{
+    /// <summary>
+    /// Generate client.
+    /// </summary>
+    public bool Client { get; set; }
+
+    /// <summary>
+    /// Generate server.
+    /// </summary>
+    public bool Server { get; set; }
+
+    /// <summary>
+    /// Should we also build the relevant project.
+    /// </summary>
+    public bool SkipBuild { get; set; }
+
+    // CommandLineArgs, 3rd of her name.
+    public static bool TryParse(IReadOnlyList<string> args, [NotNullWhen(true)] out CommandLineArgs? parsed)
+    {
+        parsed = null;
+        bool client = true;
+        bool server = true;
+        var skipBuild = false;
+
+        using var enumerator = args.GetEnumerator();
+        var i = -1;
+
+        while (enumerator.MoveNext())
+        {
+            i++;
+            var arg = enumerator.Current;
+            if (i == 0)
+            {
+                switch (arg)
+                {
+                    case "client":
+                        server = false;
+                        break;
+                    case "server":
+                        client = false;
+                        break;
+                }
+            }
+
+            switch (arg)
+            {
+                case "--skip-build":
+                    skipBuild = true;
+                    break;
+                case "--help":
+                    PrintHelp();
+                    return false;
+                default:
+                    Console.WriteLine("Unknown argument: {0}", arg);
+                    break;
+            }
+        }
+
+        parsed = new CommandLineArgs(client, server, skipBuild);
+        return true;
+    }
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine(@"
+Usage: Goobstation.Bootstrap [client/server/(both)] [options]
+
+Options:
+  --skip-build          Should we skip building the project and use what's already there.
+");
+    }
+
+    private CommandLineArgs(
+        bool client,
+        bool server,
+        bool skipBuild)
+    {
+        Client = client;
+        Server = server;
+        SkipBuild = skipBuild;
+    }
+}

--- a/Goobstation.Bootstrap/Program.cs
+++ b/Goobstation.Bootstrap/Program.cs
@@ -1,40 +1,34 @@
 using System.Diagnostics;
 using Goobstation.Bootstrap;
 
-await BootstrapBuilder.BuildAll();
+var repoRoot = BootstrapBuilder.FindRepoRoot();
+Environment.CurrentDirectory = repoRoot;
 
-var command = args.Length > 0 ? args[0].ToLowerInvariant() : null;
+if (!CommandLineArgs.TryParse(args, out var parsed))
+    return 0;
 
-switch (command)
+// TODO if server/client argument is specified, we should build only server/client modules here
+if (!parsed.SkipBuild)
+    await BootstrapBuilder.BuildAll();
+
+if (parsed.Client && parsed.Server)
 {
-    case null:
-        var server = StartProject("Content.Server/Content.Server.csproj");
-        var client = StartProject("Content.Client/Content.Client.csproj");
-        if (server == null || client == null)
-            return 1;
-        server.WaitForExit();
-        client.WaitForExit();
-        return 0;
-
-    case "run-client":
-        return RunProject("Content.Client/Content.Client.csproj");
-
-    case "run-server":
-        return RunProject("Content.Server/Content.Server.csproj");
-
-    default:
-        PrintUsage();
+    var server = StartProject("Content.Server/Content.Server.csproj");
+    var client = StartProject("Content.Client/Content.Client.csproj");
+    if (server == null || client == null)
         return 1;
+    server.WaitForExit();
+    client.WaitForExit();
+    return 0;
 }
 
-static void PrintUsage()
-{
-    Console.WriteLine("Usage: Goobstation.Bootstrap [command]");
-    Console.WriteLine();
-    Console.WriteLine("  (no args)    - Build and run client + server");
-    Console.WriteLine("  run-client   - Build and run the client only");
-    Console.WriteLine("  run-server   - Build and run the server only");
-}
+if (parsed.Client)
+    return RunProject("Content.Client/Content.Client.csproj");
+
+if (parsed.Server)
+    return RunProject("Content.Server/Content.Server.csproj");
+
+return 1;
 
 static int RunProject(string projectPath)
 {

--- a/Goobstation.Bootstrap/Program.cs
+++ b/Goobstation.Bootstrap/Program.cs
@@ -7,14 +7,11 @@ Environment.CurrentDirectory = repoRoot;
 if (!CommandLineArgs.TryParse(args, out var parsed))
     return 0;
 
-// TODO if server/client argument is specified, we should build only server/client modules here
-if (!parsed.SkipBuild)
-    await BootstrapBuilder.BuildAll();
-
 if (parsed.Client && parsed.Server)
 {
-    var server = StartProject("Content.Server/Content.Server.csproj");
-    var client = StartProject("Content.Client/Content.Client.csproj");
+    await BootstrapBuilder.BuildAll();
+    var server = StartProject("Content.Server/Content.Server.csproj", parsed.ShellExecute);
+    var client = StartProject("Content.Client/Content.Client.csproj", parsed.ShellExecute);
     if (server == null || client == null)
         return 1;
     server.WaitForExit();
@@ -23,29 +20,35 @@ if (parsed.Client && parsed.Server)
 }
 
 if (parsed.Client)
-    return RunProject("Content.Client/Content.Client.csproj");
+{
+    await BootstrapBuilder.BuildClient();
+    return RunProject("Content.Client/Content.Client.csproj", parsed.ShellExecute);
+}
 
 if (parsed.Server)
-    return RunProject("Content.Server/Content.Server.csproj");
+{
+    await BootstrapBuilder.BuildServer();
+    return RunProject("Content.Server/Content.Server.csproj", parsed.ShellExecute);
+}
 
 return 1;
 
-static int RunProject(string projectPath)
+static int RunProject(string projectPath, bool useShellExecute)
 {
-    using var process = StartProject(projectPath);
+    using var process = StartProject(projectPath, useShellExecute);
     if (process == null)
         return 1;
     process.WaitForExit();
     return process.ExitCode;
 }
 
-static Process? StartProject(string projectPath)
+static Process? StartProject(string projectPath, bool useShellExecute)
 {
     var process = Process.Start(new ProcessStartInfo
     {
         FileName = BootstrapBuilder.DotnetPath,
         Arguments = $"run --project {projectPath}",
-        UseShellExecute = false
+        UseShellExecute = useShellExecute,
     });
 
     if (process == null)

--- a/Scripts/bat/runQuickClient.bat
+++ b/Scripts/bat/runQuickClient.bat
@@ -1,6 +1,6 @@
 @echo off
 cd ../../
 
-call dotnet run --project Modules\GoobStation\Content.Goobstation.Client --no-build %*
+call dotnet run --project Goobstation.Bootstrap client --skip-build %*
 
 pause

--- a/Scripts/bat/runQuickServer.bat
+++ b/Scripts/bat/runQuickServer.bat
@@ -1,6 +1,6 @@
 @echo off
 cd ../../
 
-call dotnet run --project Modules\Goobstation\Content.Goobstation.Server --no-build %*
+call dotnet run --project Goobstation.Bootstrap server --skip-build %*
 
 pause

--- a/Scripts/sh/runQuickClient.sh
+++ b/Scripts/sh/runQuickClient.sh
@@ -6,4 +6,4 @@ if [ "$(dirname $0)" != "." ]; then
 fi
 
 cd ../../
-dotnet run --project Modules/GoobStation/Content.Goobstation.Client --no-build
+dotnet run --project Goobstation.Bootstrap client --skip-build

--- a/Scripts/sh/runQuickServer.sh
+++ b/Scripts/sh/runQuickServer.sh
@@ -6,4 +6,4 @@ if [ "$(dirname $0)" != "." ]; then
 fi
 
 cd ../../
-dotnet run --project Modules/GoobStation/Content.Goobstation.Server --no-build
+dotnet run --project Goobstation.Bootstrap server --skip-build


### PR DESCRIPTION
- If server/client is specified, Bootstrap only builds the required modules without compiling the opposite side
- Bootstrap now supports launching without compiling anything for consistency (`--skip-build` option)
- Bootstrap opens another window for the run project, unless you pass a special option (`--no-shell-execute` option)

closes #18