### PR TITLE
Content.Common project

### DIFF
--- a/Content.Common/Content.Common.csproj
+++ b/Content.Common/Content.Common.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <Import Project="..\MSBuild\Content.props"/>
+
+  <Import Project="..\RobustToolbox\Imports\Lidgren.props" />
+  <Import Project="..\RobustToolbox\Imports\Shared.props" />
+
+  <Import Project="..\RobustToolbox\MSBuild\Robust.Properties.targets" />
+</Project>

--- a/Content.Common/FixedPoint/FixedPoint2.cs
+++ b/Content.Common/FixedPoint/FixedPoint2.cs
@@ -1,8 +1,9 @@
 using System.Globalization;
-using System.Linq;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
 
+// ReSharper disable once CheckNamespace
 namespace Content.Shared.FixedPoint
 {
     /// <summary>

--- a/Content.Common/FixedPoint/FixedPoint4.cs
+++ b/Content.Common/FixedPoint/FixedPoint4.cs
@@ -1,8 +1,9 @@
 using System.Globalization;
-using System.Linq;
 using Robust.Shared.Serialization;
+using Robust.Shared.Serialization.Manager.Attributes;
 using Robust.Shared.Utility;
 
+// ReSharper disable once CheckNamespace
 namespace Content.Shared.FixedPoint
 {
     /// <summary>

--- a/Content.Common/Inventory/IClothingSlots.cs
+++ b/Content.Common/Inventory/IClothingSlots.cs
@@ -1,0 +1,7 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Content.Shared.Inventory;
+
+public interface IClothingSlots
+{
+    SlotFlags Slots { get; }
+}

--- a/Content.Common/Inventory/IInventoryRelayEvent.cs
+++ b/Content.Common/Inventory/IInventoryRelayEvent.cs
@@ -1,0 +1,17 @@
+﻿// ReSharper disable once CheckNamespace
+namespace Content.Shared.Inventory;
+
+/// <summary>
+///     Events that should be relayed to inventory slots should implement this interface.
+/// </summary>
+public interface IInventoryRelayEvent
+{
+    /// <summary>
+    ///     What inventory slots should this event be relayed to, if any?
+    /// </summary>
+    /// <remarks>
+    ///     In general you may want to exclude <see cref="SlotFlags.POCKET"/>, given that those items are not truly
+    ///     "equipped" by the user.
+    /// </remarks>
+    public SlotFlags TargetSlots { get; }
+}

--- a/Content.Common/Inventory/SlotFlags.cs
+++ b/Content.Common/Inventory/SlotFlags.cs
@@ -1,3 +1,4 @@
+// ReSharper disable once CheckNamespace
 using Robust.Shared.Serialization;
 
 namespace Content.Shared.Inventory;

--- a/Content.Shared/Inventory/InventorySystem.Relay.cs
+++ b/Content.Shared/Inventory/InventorySystem.Relay.cs
@@ -192,22 +192,4 @@ public sealed class InventoryRelayedEvent<TEvent> : EntityEventArgs
     }
 }
 
-public interface IClothingSlots
-{
-    SlotFlags Slots { get; }
-}
-
-/// <summary>
-///     Events that should be relayed to inventory slots should implement this interface.
-/// </summary>
-public interface IInventoryRelayEvent
-{
-    /// <summary>
-    ///     What inventory slots should this event be relayed to, if any?
-    /// </summary>
-    /// <remarks>
-    ///     In general you may want to exclude <see cref="SlotFlags.POCKET"/>, given that those items are not truly
-    ///     "equipped" by the user.
-    /// </remarks>
-    public SlotFlags TargetSlots { get; }
-}
+// Goobstation edit - moved IClothingSlots and IInventoryRelayEvent to Content.Common

--- a/Modules/GoobStation/Content.Goobstation.Common/Content.Goobstation.Common.csproj
+++ b/Modules/GoobStation/Content.Goobstation.Common/Content.Goobstation.Common.csproj
@@ -8,5 +8,9 @@
   <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Content.Common\Content.Common.csproj" />
+  </ItemGroup>
+
   <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
 </Project>

--- a/Modules/Lavaland/Content.Lavaland.Common/Content.Lavaland.Common.csproj
+++ b/Modules/Lavaland/Content.Lavaland.Common/Content.Lavaland.Common.csproj
@@ -8,5 +8,9 @@
   <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Content.Common\Content.Common.csproj" />
+  </ItemGroup>
+
   <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
 </Project>

--- a/SpaceStation14.slnx
+++ b/SpaceStation14.slnx
@@ -139,6 +139,7 @@
   </Folder>
   <Project Path="Content.Benchmarks/Content.Benchmarks.csproj" />
   <Project Path="Content.Client/Content.Client.csproj" />
+  <Project Path="Content.Common/Content.Common.csproj" />
   <Project Path="Content.IntegrationTests/Content.IntegrationTests.csproj" />
   <Project Path="Content.MapRenderer/Content.MapRenderer.csproj" />
   <Project Path="Content.ModuleManager/Content.ModuleManager.csproj" />

--- a/Templates/Module/Content.Template.Common/Content.Template.Common.csproj
+++ b/Templates/Module/Content.Template.Common/Content.Template.Common.csproj
@@ -8,5 +8,9 @@
   <Import Project="..\..\..\RobustToolbox\Imports\Lidgren.props" />
   <Import Project="..\..\..\RobustToolbox\Imports\Shared.props" />
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Content.Common\Content.Common.csproj" />
+  </ItemGroup>
+
   <Import Project="..\..\..\RobustToolbox\MSBuild\Robust.Properties.targets" />
 </Project>


### PR DESCRIPTION
## About the PR
Added a new `Content.Common` project.

## Why
It's needed so some mechanics can be split to Modules without any issues.

## Technical details
Basically, `Content.Common` is a common module for the core.
In order to prevent issues with merge conflicts with upstream code, files that were moved from `Content.Shared` still have the same namespace, and the warning is suppressed.

In this PR `Content.Common` contains some Inventory-related interfaces, SlotFlags, and FixedPoint data structures.

## Breaking changes
All `Content.*.Common` projects now have to depend on `Content.Common` module.
